### PR TITLE
Add a map to represent the current version of ZeroMQ

### DIFF
--- a/src/zeromq/zmq.clj
+++ b/src/zeromq/zmq.clj
@@ -5,6 +5,11 @@
    java.nio.ByteBuffer
    java.net.ServerSocket))
 
+(def ^:const version
+  {:major (ZMQ/getMajorVersion)
+   :minor (ZMQ/getMinorVersion)
+   :patch (ZMQ/getPatchVersion)})
+
 (def ^:const zmq-three?
   (> (ZMQ/getFullVersion) (ZMQ/makeVersion 3 0 0)))
 


### PR DESCRIPTION
Added so that the version example in the guide can be written for Clojure
