### PR TITLE
Added zeromq.zmq/send-all function

### DIFF
--- a/src/zeromq/zmq.clj
+++ b/src/zeromq/zmq.clj
@@ -218,6 +218,18 @@
         (recur new-acc)
         (persistent! new-acc)))))
 
+(defn send-all
+  "Send all data parts to the socket.
+  coll is a seq containing byte arrays."
+  [^ZMQ$Socket socket coll]
+  (loop [i 0]
+    (let [frame (nth coll i)
+          flags (if (= i (- (count coll) 1))
+                  0
+                  send-more)]
+      (send socket frame flags)
+      (when (< (+ i 1) (count coll)) (recur (+ i 1))))))
+
 (defn ^ZMQ$Socket set-linger
   "The linger option shall set the linger period for the specified socket. The
    linger period determines how long pending messages which have yet to be sent


### PR DESCRIPTION
Clearly a useful function that is missing for some reason. Is it OK to leave the type hinting out from coll argument?